### PR TITLE
Invalid default channel ?

### DIFF
--- a/ledgerLayer.h
+++ b/ledgerLayer.h
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define DEFAULT_LEDGER_CHANNEL 0x0101
+#define DEFAULT_LEDGER_CHANNEL 0x01
 #define LEDGER_HID_PACKET_SIZE 64
 
 int wrapCommandAPDU(unsigned int channel, const unsigned char *command, size_t commandLength, unsigned int packetSize, unsigned char *out, size_t outLength);


### PR DESCRIPTION
The java API have default channel set to 0x01, not 0x0101.

https://github.com/LedgerHQ/btchip-java-api/blob/master/src-libusb/com/btchip/comm/hid/BTChipTransportHID.java

I tried to compile this C code in visual studio with HIDAPI transport.
With 0x0101, the hid_write fails. With 0x01, it passes but fails shortly after, timing out on the second hid_read.