### PR TITLE
Update with Nano Splus and Nano X

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Note : Ledger Wallet only supports HIDAPI following version 1.4.14 for HW.1 / Na
 Building on Linux and OS X
 ---------------------------
 
-Build with GNU make (needs libusb 1.0 development APIs for Makefile.libusb or HID API from Signal 11 for Makefile.hidapi, such as the libhidapi-dev package), each command is described below
+Build with GNU make (needs libusb 1.0 development APIs for Makefile.libusb or HID API from Signal 11 for Makefile.hidapi, such as the libhidapi-dev package), each command is described below. It may be necessary to install the following packages:
+* sudo apt install libhidapi-dev
+* sudo apt install libusb-1.0-0-dev
+* sudo apt install libconfig-dev
 
 Building on Windows
 -------------------

--- a/bitcoinAmount.h
+++ b/bitcoinAmount.h
@@ -22,6 +22,8 @@
 
 #include <inttypes.h>
 
+extern inline int64_t atoi64(const char* psz);
+
 int parseStringAmount(char *amount, int64_t* result);
 void writeHexAmount(int64_t amount, unsigned char *buffer);
 void writeHexAmountBE(int64_t amount, unsigned char *buffer);

--- a/dongleCommHidHidapi.c
+++ b/dongleCommHidHidapi.c
@@ -27,6 +27,8 @@
 #define BTCHIP_HID_BOOTLOADER_PID 0x1807
 #define BLUE_PID 0x0000
 #define NANOS_PID 0x0001
+#define NANOSP_PID 0x5011
+#define NANOX_PID 0x0021
 
 #define TIMEOUT 60000
 #define SW1_DATA 0x61
@@ -164,7 +166,18 @@ hid_device* getFirstDongleHidHidapi(unsigned char *ledger) {
 	if (result != NULL) {
 		*ledger = 1;
 		return result;
-	}	
+	}
+	result = hid_open(LEDGER_VID, NANOSP_PID, NULL);
+		if (result != NULL) {
+			*ledger = 1;
+			return result;
+		}
+	result = hid_open(LEDGER_VID, NANOX_PID, NULL);
+				if (result != NULL) {
+					*ledger = 1;
+					return result;
+				}
+
 	return NULL;
 }
 


### PR DESCRIPTION
Updating the PIDs of NanoSP and NanoX

nota: works properly to send APDU, syntax changes lead to ineffective tests.

TBD: Update tests with correct APDU syntax.